### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,6 @@
 name: Aos RPI release
+permissions:
+  contents: write
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/aosedge/meta-aos-rpi/security/code-scanning/2](https://github.com/aosedge/meta-aos-rpi/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimum required permissions. Based on the workflow's functionality:
- The `contents: read` permission is needed for the `Checkout` step to access the repository's contents.
- The `contents: write` permission is required for the `Publish Release` step to create and upload release artifacts.
- No other permissions are necessary for this workflow.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
