### PR TITLE
install: catch silent gunzip failures during flash

### DIFF
--- a/meta-aos-rpi-install/recipes-core/initrdscripts/files/install_script.sh
+++ b/meta-aos-rpi-install/recipes-core/initrdscripts/files/install_script.sh
@@ -75,6 +75,27 @@ wait_for_block_device() {
     return 0
 }
 
+flash_image() {
+    src="$1"
+    dst="$2"
+    pipe="/tmp/flash_pipe"
+
+    rm -f "$pipe"
+    mkfifo "$pipe"
+
+    gunzip -c "$src" >"$pipe" &
+    gunzip_pid=$!
+
+    dd of="$dst" bs=8096 <"$pipe"
+
+    rm -f "$pipe"
+
+    if ! wait "$gunzip_pid"; then
+        echo "ERROR: failed to decompress $src, aborting install" >&2
+        exit 1
+    fi
+}
+
 update_user() {
     mkdir -p /sd1 /flash1
     mount -t auto /dev/mmcblk0p1 /sd1/
@@ -122,7 +143,7 @@ mount -t auto /dev/mmcblk0p2 /sd2
 
 echo "Flashing root device..."
 
-gunzip -c /sd2/rootfs.img.gz | dd of="/dev/$BLOCK_DEVICE" bs=8096
+flash_image /sd2/rootfs.img.gz "/dev/$BLOCK_DEVICE"
 mkfs.ext4 -F -E lazy_journal_init=1 "/dev/$BLOCK_DEVICE_AOS_PARTITION"
 
 mount -t auto "/dev/$BLOCK_DEVICE_AOS_PARTITION" /flash3
@@ -133,7 +154,7 @@ echo "Flashing SD card..."
 
 cp /sd2/boot.img.gz /flash3 
 umount /sd2
-gunzip -c /flash3/boot.img.gz | dd of=/dev/mmcblk0 bs=8096
+flash_image /flash3/boot.img.gz /dev/mmcblk0
 rm /flash3/boot.img.gz
 
 echo


### PR DESCRIPTION
After running the AosCore installer, mounting the var partition (nvme0n1p2) fails with Can't find ext4 filesystem / bogus number of reserved sectors, even though the GPT partition table looks correct (p1, p2, p3 all show the right sizes).

Root cause: The install initramfs (install_script.sh) flashes the disk with:
gunzip -c /sd2/rootfs.img.gz | dd of="/dev/$BLOCK_DEVICE" bs=8096

Because the script only has set -e (no pipefail), it only ever checks dd's exit status — never gunzip's. When gunzip hit truncated/corrupted input partway through decompression, it died silently; dd just saw a clean EOF and exited 0.

The script proceeded to print "successfully installed" and reboot into a disk that was only partially written: p1 (rootfs) got fully flashed, but p2 (var) and beyond never received any data — confirmed by dumping p2's superblock region, which was all zeros.

The GPT partition table itself was unaffected (it's written at the very start of the image), which is why lsblk/fdisk reported a structurally correct layout that masked the missing content.

Fix applied: install_script.sh now routes flash steps through a flash_image() helper that pipes gunzip into dd via a named FIFO and explicitly waits on the gunzip process.

A failed decompression is now caught immediately — the script aborts with an error instead of silently continuing and reporting false success.


Reviewed-by: Mykola Kobets <mykola_kobets@epam.com>
Reviewed-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>