### PR TITLE
yaml: add main node hostname to /etc/hosts

### DIFF
--- a/aos-rpi.yaml
+++ b/aos-rpi.yaml
@@ -573,6 +573,7 @@ parameters:
                 - [AOS_MAIN_NODE, "1"]
                 - [AOS_NODE_IP, "%{MAIN_NODE_IP}/24"]
                 - [AOS_USE_DHCP, "1"]
+                - [AOS_HOSTS:append, " %{MAIN_NODE_IP}=%{MAIN_NODE_HOSTNAME}"]
 
               layers:
                 - "../meta-aos-rpi/meta-aos-rpi-domd-main"


### PR DESCRIPTION
Ensures the main node's DNS name resolves locally by appending its IP-to-hostname mapping to AOS_HOSTS.


Reviewed-by: Mykhailo Lohvynenko <mykhailo_lohvynenko@epam.com>
Reviewed-by: Mykola Kobets <mykola_kobets@epam.com>